### PR TITLE
Fixed "fulldata" typo

### DIFF
--- a/ADReaper.go
+++ b/ADReaper.go
@@ -30,7 +30,7 @@ func main() {
 
 	filterMsg := "\nFilters to use for users/groups/computers\n"
 	filterMsg += "\nlist - lists all objects only"
-	filterMsg += "\nfulldata - list all objects with properties"
+	filterMsg += "\nfull-data - list all objects with properties"
 	filterMsg += "\nmembership - lists all members from an object"
 	filterMsg += "\n\n"
 

--- a/POC.md
+++ b/POC.md
@@ -33,7 +33,7 @@ PS C:\Users\redteamer\Desktop\shared> .\ADReaper.exe
             Filters to use for users/groups/computers
 
             list - lists all objects only
-            fulldata - list all objects with properties
+            full-data - list all objects with properties
             membership - lists all members from an object
 
             (default "list")

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ PS C:\Users\redteamer\Desktop\shared> .\ADReaper.exe
             Filters to use for users/groups/computers
 
             list - lists all objects only
-            fulldata - list all objects with properties
+            full-data - list all objects with properties
             membership - lists all members from an object
 
             (default "list")


### PR DESCRIPTION
Changed all occurrences of "fulldata" to "full-data"

"fulldata" is not a functional command, as per [ldapquery/ldapData.go](https://github.com/AidenPearce369/ADReaper/blob/77e5ef4ef6b8358e3667765baf4236eb1ad441f6/ldapquery/ldapData.go#L30) and [README.md](https://github.com/AidenPearce369/ADReaper/blob/main/README.md) and [POC.md](https://github.com/AidenPearce369/ADReaper/blob/main/POC.md)