### PR TITLE
Added ability to run multiple commands at the same time

### DIFF
--- a/ADReaper.go
+++ b/ADReaper.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 
-	commandStr := "\nCommand to run\n"
+	commandStr := "\nCommand(s) to run\n"
 	commandStr += "\n\tdc              - to list domain controllers"
 	commandStr += "\n\tdomain-trust    - to list domain trust"
 	commandStr += "\n\tusers           - to list all users"
@@ -59,11 +59,29 @@ func main() {
 	ldapServer := flag.String("dc", "", "\nEnter the DC\n")
 	ldapBind := flag.String("user", "", "\nEnter the Username\n")
 	ldapPassword := flag.String("password", "", "\nEnter the Password\n")
-	command := flag.String("command", "", commandStr)
+	commands := flag.String("command", "", commandStr)
 	filter := flag.String("filter", "list", filterMsg)
 	name := flag.String("name", "", nameMsg)
 	flag.Parse()
-	if len(*ldapServer) == 0 || len(*ldapBind) == 0 || len(*ldapPassword) == 0 || len(*command) == 0 || !(cmd[*command]) {
+
+	// get list of all commands by splitting on "," or " "
+	var commandList []string
+
+	if strings.Contains(*commands, ",") {
+		commandList = strings.Split(*commands, ",")
+	} else {
+		commandList = strings.Split(*commands, " ")
+	}
+
+	for _,command := range commandList{
+		if !(cmd[command]) || len(command) == 0 {
+			flag.PrintDefaults()
+			os.Exit(-1)
+		}
+	}
+
+
+	if len(*ldapServer) == 0 || len(*ldapBind) == 0 || len(*ldapPassword) == 0 {
 		flag.PrintDefaults()
 		os.Exit(-1)
 	}
@@ -88,5 +106,7 @@ func main() {
 	// fmt.Println(string(out))
 
 	//querying
-	ldapquery.LDAPlistquery(*ldapServer, *ldapBind, *ldapPassword, baseDN, *command, *filter, *name)
+	for _,command := range commandList {
+		ldapquery.LDAPlistquery(*ldapServer, *ldapBind, *ldapPassword, baseDN, command, *filter, *name)
+	}
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ADReaper performs enumeration with various commands that performs LDAP queries w
 ```c
 PS C:\Users\redteamer\Desktop\shared> .\ADReaper.exe
 
-      -command string
+      -command(s) string
 
             Command to run
                   dc              - to list domain controllers
@@ -202,6 +202,11 @@ To list AD objects with ```Unconstrained Delegation``` enabled,
 
 ```c
 .\ADReaper.exe -dc <dc.domain> -user <username> -password <password> -command unconstrained 
+```
+
+To list AD objects with ```Unconstrained Delegation``` enabled and all ```AS-REP roastable accounts```
+```c
+.\ADReaper.exe -dc <dc.domain> -user <username> -password <password> -command unconstrained,asreproast
 ```
 
 ## To-Do

--- a/ldapquery/ldapData.go
+++ b/ldapquery/ldapData.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/ldap.v2"
 )
 
+
 func LDAP_QueryData(
 	conn *ldap.Conn,
 	baseDN string,


### PR DESCRIPTION
The base functionality works exactly the same, except now users can run multiple commands by entering a comma or whitespace-separated list

Example:
```
.\ADReaper.exe -dc <dc.domain> -user <username> -password <password> -command unconstrained,asreproast
```